### PR TITLE
Search for fonts in subdirectories

### DIFF
--- a/lib/ruby_mapnik/mapnik/font_engine.rb
+++ b/lib/ruby_mapnik/mapnik/font_engine.rb
@@ -26,7 +26,7 @@ module Mapnik
     DEFAULT_VALID_EXTENSIONS = ['ttf','otf','ttc','pfa','pfb','ttc','dfont']
     
     def self.register_fonts(path, valid_extensions = DEFAULT_VALID_EXTENSIONS)
-      file_names = Dir.glob(File.join("#{path}", "*.{#{valid_extensions.join(',')}}"))
+      file_names = Dir.glob(File.join("#{path}", "**", "*.{#{valid_extensions.join(',')}}"))
       file_names.each{|filename| register_font(filename)} 
     end
     


### PR DESCRIPTION
Fore example, in Ubuntu /usr/share/fonts/truetype contains no font files, but directories with font files for different font families.
