### PR TITLE
More robust rice path in CFLAGS.

### DIFF
--- a/ext/ruby_mapnik/extconf.rb
+++ b/ext/ruby_mapnik/extconf.rb
@@ -40,7 +40,8 @@ INCLUDEDIR = Config::CONFIG['includedir']
 
 $LDFLAGS += " " + %x{mapnik-config --libs}.chomp + " "
 
-$CFLAGS = '-I/Library/Ruby/Gems/1.8/gems/rice-1.4.3/'
+rice_path = Gem.latest_spec_for('rice').full_gem_path
+$CFLAGS = "-I#{rice_path}"
 
 # force whitespace padding to avoid: https://github.com/mapnik/Ruby-Mapnik/issues/7
 $CFLAGS += " " + %x{mapnik-config --cflags}.chomp + " "


### PR DESCRIPTION
The hardcoded rice version number in the include path in CFLAGS seems like a (very effective) hack. This change queries Rubygems for the gem path, so it should work for newer versions of rice, on different platforms.

I hope this will ease the transition to rice 1.5.