### PR TITLE
Add more array methods to MapLayerContainer and LayerStyleContainer.

### DIFF
--- a/lib/ruby_mapnik/mapnik/layer.rb
+++ b/lib/ruby_mapnik/mapnik/layer.rb
@@ -25,7 +25,7 @@ module Mapnik
     
     extend Forwardable
     
-    def_delegators :@collection, :empty?, :any?, :length, :first, :count
+    def_delegators :@collection, :empty?, :any?, :length, :first, :[], :count, :each, :map
     
     def initialize(collection)
       @collection = collection

--- a/lib/ruby_mapnik/mapnik/map.rb
+++ b/lib/ruby_mapnik/mapnik/map.rb
@@ -43,7 +43,7 @@ module Mapnik
     
     extend Forwardable
     
-    def_delegators :@collection, :empty?, :any?, :length, :first, :[], :count
+    def_delegators :@collection, :empty?, :any?, :length, :first, :[], :count, :each, :map
     
     def initialize(collection)
       @collection = collection


### PR DESCRIPTION
This expands two of the Container classes to have a few more (useful) array methods.

I'm not sure if other containers should have them too, or if there's a better approach to save having to list all these methods, but for now this is what's needed for some work in mapnik-legendary.
