### PR TITLE
Implementing AttributeCollector (Help Wanted - not for merging)

### DIFF
--- a/ext/ruby_mapnik/_mapnik.h
+++ b/ext/ruby_mapnik/_mapnik.h
@@ -58,8 +58,10 @@ SOFTWARE.
 #include "_mapnik_polygon_pattern_symbolizer.rb.h"
 #include "_mapnik_line_pattern_symbolizer.rb.h" 
 #include "_mapnik_markers_symbolizer.rb.h" 
-#include "_mapnik_shield_symbolizer.rb.h"  
- 
+#include "_mapnik_shield_symbolizer.rb.h"
+
+#include "_mapnik_attribute_collector.rb.h"
+
 void register_mapnik();
 
 #endif

--- a/ext/ruby_mapnik/_mapnik_attribute_collector.rb.cpp
+++ b/ext/ruby_mapnik/_mapnik_attribute_collector.rb.cpp
@@ -1,0 +1,44 @@
+/*****************************************************************************
+Copyright (C) 2011 Elliot Laster
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the ‘Software’), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED ‘AS IS’, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ *****************************************************************************/
+#include "_mapnik_attribute_collector.rb.h"
+
+// Rice
+#include <rice/Data_Type.hpp>
+#include <rice/Constructor.hpp>
+#include <rice/Class.hpp>
+
+// Mapnik
+#include <mapnik/attribute_collector.hpp>
+
+// stl
+#include <set>
+
+
+void register_attribute_collector(Rice::Module rb_mapnik){
+
+  Rice::Data_Type< mapnik::attribute_collector > rb_cattribute_collector = Rice::define_class_under< mapnik::attribute_collector >(rb_mapnik, "AttributeCollector");
+
+  //rb_cattribute_collector.define_constructor(Rice::Constructor< mapnik::attribute_collector,std::set<std::string> >());
+
+  //rb_cattribute_collector.define_method("add_rule", &mapnik::attribute_collector::operator());
+
+}

--- a/ext/ruby_mapnik/_mapnik_attribute_collector.rb.h
+++ b/ext/ruby_mapnik/_mapnik_attribute_collector.rb.h
@@ -19,35 +19,14 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
 SOFTWARE.
  *****************************************************************************/
-#include "_mapnik.h"
+#ifndef PIKA2_MAPNIK_ATTRIBUTE_COLLECTOR
+#define PIKA2_MAPNIK_ATTRIBUTE_COLLECTOR
 
-void register_mapnik(){
-  Rice::Module rb_mapnik = Rice::define_module("Mapnik");
-  
-  register_color(rb_mapnik);
-  register_coord(rb_mapnik);
-  register_datasource(rb_mapnik);
-  register_datasource_cache(rb_mapnik);
-  register_envelope(rb_mapnik);
-  register_feature(rb_mapnik);
-  register_polygon_symbolizer(rb_mapnik);
-  register_line_symbolizer(rb_mapnik);
-  register_stroke(rb_mapnik);
-  register_rule(rb_mapnik);
-  register_expression(rb_mapnik);
-  register_symbolizer(rb_mapnik);
-  register_style(rb_mapnik);
-  register_layer(rb_mapnik);
-  register_map(rb_mapnik);
-  register_projection(rb_mapnik);
-  register_text_symbolizer(rb_mapnik);
-  register_font_engine(rb_mapnik);
-  register_raster_symbolizer(rb_mapnik);
-  register_raster_colorizer(rb_mapnik);
-  register_point_symbolizer(rb_mapnik);
-  register_polygon_pattern_symbolizer(rb_mapnik);
-  register_line_pattern_symbolizer(rb_mapnik);
-  register_markers_symbolizer(rb_mapnik);
-  register_shield_symbolizer(rb_mapnik);
-  register_attribute_collector(rb_mapnik);
+namespace Rice
+{
+ class Module; 
 }
+
+void register_attribute_collector(Rice::Module rb_mapnik);
+
+#endif

--- a/test/test_mapnik_attribute_collector.rb
+++ b/test/test_mapnik_attribute_collector.rb
@@ -1,0 +1,50 @@
+=begin 
+ ******************************************************************************
+ * 
+ * Copyright (C) 2011 Elliot Laster
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ ******************************************************************************
+=end
+require "test_helper"
+
+class TestMapnikAttributeCollector < Test::Unit::TestCase
+
+  def test_presence
+    assert Mapnik::AttributeCollector
+  end
+
+  def test_should_instantiate
+    assert Mapnik::AttributeCollector.new
+  end
+
+  def test_should_accept_rules
+    attribute_collector = Mapnik::AttributeCollector.new
+    assert attribute_collector.add_rule(Mapnik::Rule.new)
+  end
+
+  def test_should_give_attributes
+    rule = Mapnik::Rule.new
+    expression_string = "([place]='town')"
+    expression = Mapnik::Expression.parse(expression_string)
+    rule.filter = expression
+
+    attribute_collector = Mapnik::AttributeCollector.new
+    attribute_collector.add_rule(rule)
+
+    assert_equal attribute_collector.attributes, ['place']
+  end
+end


### PR DESCRIPTION
I've started implementing AttributeCollector, which is required for a project that I'm working on (see https://github.com/gravitystorm/mapnik-legendary/issues/1 if you're interested)

Unfortunately my monkey-see-monkey-do style of C++ programming has run out of juice, and so any help here would be appreciated.

The C++ mapnik::attribute_collector would be distinctly un-ruby-ish, so I've written some tests to flesh out how I think it should behave:

```
a = AttributeCollector.new
a.add_rule(rule)
puts a.attributes
```

Now I'm stumped on how to write the `define_constructor` and `define_method` sections, since they are mostly unrelated to the C++ constructor and methods. For example, the C++ constructor takes a std::set of strings by reference in its signature, and I don't want to do that in ruby.

Any suggestions of approaches would be appreciated, or if someone can point my to something similar that already exists in Ruby-Mapnik then I'll go back to my monkey-see approach :-).
